### PR TITLE
Include redux-observable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^17.0.2",
         "react-redux": "^7.2.6",
         "react-scripts": "5.0.0",
+        "redux-observable": "^2.0.0",
         "typescript": "~4.5.5"
       }
     },
@@ -13415,6 +13416,23 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "node_modules/redux-observable": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redux-observable/-/redux-observable-2.0.0.tgz",
+      "integrity": "sha512-FJz4rLXX+VmDDwZS/LpvQsKnSanDOe8UVjiLryx1g3seZiS69iLpMrcvXD5oFO7rtkPyRdo/FmTqldnT3X3m+w==",
+      "dependencies": {
+        "rxjs": "^7.0.0",
+        "tslib": "~2.1.0"
+      },
+      "peerDependencies": {
+        "redux": ">=4 <5"
+      }
+    },
+    "node_modules/redux-observable/node_modules/tslib": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+    },
     "node_modules/redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
@@ -13787,6 +13805,14 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
+      "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -25676,6 +25702,22 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "redux-observable": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/redux-observable/-/redux-observable-2.0.0.tgz",
+      "integrity": "sha512-FJz4rLXX+VmDDwZS/LpvQsKnSanDOe8UVjiLryx1g3seZiS69iLpMrcvXD5oFO7rtkPyRdo/FmTqldnT3X3m+w==",
+      "requires": {
+        "rxjs": "^7.0.0",
+        "tslib": "~2.1.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
+      }
+    },
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",
@@ -25934,6 +25976,14 @@
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "requires": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "rxjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.4.tgz",
+      "integrity": "sha512-h5M3Hk78r6wAheJF0a5YahB1yRQKCsZ4MsGdZ5O9ETbVtjPcScGfrMmoOq7EBsCRzd4BDkvDJ7ogP8Sz5tTFiQ==",
+      "requires": {
+        "tslib": "^2.1.0"
       }
     },
     "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.6",
     "react-scripts": "5.0.0",
+    "redux-observable": "^2.0.0",
     "typescript": "~4.5.5"
   },
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import logo from './logo.svg';
-import { Counter } from './features/counter/Counter';
-import './App.css';
+import React from "react";
+import logo from "./logo.svg";
+import { Counter } from "./features/counter/Counter";
+import { Counter as ObservableCounter } from "./features/observable-counter/Counter";
+import "./App.css";
 
 function App() {
   return (
@@ -9,6 +10,7 @@ function App() {
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
         <Counter />
+        <ObservableCounter />
         <p>
           Edit <code>src/App.tsx</code> and save to reload.
         </p>

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,11 +1,54 @@
-import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
-import counterReducer from '../features/counter/counterSlice';
+import {
+  configureStore,
+  ThunkAction,
+  Action,
+  createSlice,
+  PayloadAction,
+  combineReducers,
+  AnyAction,
+} from "@reduxjs/toolkit";
+import { createEpicMiddleware, Epic } from "redux-observable";
+import { filter, map, delay } from "rxjs/operators";
+import counterReducer from "../features/counter/counterSlice";
 
-export const store = configureStore({
-  reducer: {
-    counter: counterReducer,
+export const counter = createSlice({
+  name: "observable/counter",
+  initialState: 0,
+  reducers: {
+    increment: (state, action: PayloadAction<number>) => state + action.payload,
+    decrement: (state, action: PayloadAction<number>) => state - action.payload,
   },
 });
+
+const reducers = combineReducers({
+  observable: counter.reducer,
+  counter: counterReducer,
+});
+
+export type MyState = ReturnType<typeof reducers>;
+export type MyEpic = Epic<AnyAction, AnyAction, MyState>;
+
+const countEpic: MyEpic = (action$) => {
+  return action$.pipe(
+    filter(counter.actions.increment.match),
+    delay(5000),
+    map((action) => counter.actions.decrement(action.payload))
+  );
+};
+
+const epicMiddleware = createEpicMiddleware<AnyAction, AnyAction, MyState>();
+
+export const store = configureStore({
+  reducer: reducers,
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({ thunk: true }).concat(epicMiddleware),
+});
+
+epicMiddleware.run(countEpic);
+
+export const { increment, decrement } = counter.actions;
+
+export const selectCount = (state: MyState) => state.observable;
 
 export type AppDispatch = typeof store.dispatch;
 export type RootState = ReturnType<typeof store.getState>;

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -2,53 +2,24 @@ import {
   configureStore,
   ThunkAction,
   Action,
-  createSlice,
-  PayloadAction,
   combineReducers,
-  AnyAction,
 } from "@reduxjs/toolkit";
-import { createEpicMiddleware, Epic } from "redux-observable";
-import { filter, map, delay } from "rxjs/operators";
+
 import counterReducer from "../features/counter/counterSlice";
+import observableReducer, {
+  epicMiddleware,
+} from "../features/observable-counter/counterSlice";
 
-export const counter = createSlice({
-  name: "observable/counter",
-  initialState: 0,
-  reducers: {
-    increment: (state, action: PayloadAction<number>) => state + action.payload,
-    decrement: (state, action: PayloadAction<number>) => state - action.payload,
-  },
-});
-
-const reducers = combineReducers({
-  observable: counter.reducer,
+export const reducers = combineReducers({
+  observable: observableReducer,
   counter: counterReducer,
 });
-
-export type MyState = ReturnType<typeof reducers>;
-export type MyEpic = Epic<AnyAction, AnyAction, MyState>;
-
-const countEpic: MyEpic = (action$) => {
-  return action$.pipe(
-    filter(counter.actions.increment.match),
-    delay(5000),
-    map((action) => counter.actions.decrement(action.payload))
-  );
-};
-
-const epicMiddleware = createEpicMiddleware<AnyAction, AnyAction, MyState>();
 
 export const store = configureStore({
   reducer: reducers,
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({ thunk: true }).concat(epicMiddleware),
 });
-
-epicMiddleware.run(countEpic);
-
-export const { increment, decrement } = counter.actions;
-
-export const selectCount = (state: MyState) => state.observable;
 
 export type AppDispatch = typeof store.dispatch;
 export type RootState = ReturnType<typeof store.getState>;

--- a/src/features/observable-counter/Counter.tsx
+++ b/src/features/observable-counter/Counter.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from "react";
+import { selectCount, increment, decrement } from "../../app/store";
+import { useAppDispatch, useAppSelector } from "../../app/hooks";
+
+export function Counter() {
+  const count = useAppSelector(selectCount);
+  const dispatch = useAppDispatch();
+  const [incrementAmount, setIncrementAmount] = useState("2");
+
+  const incrementValue = Number(incrementAmount) || 0;
+
+  return (
+    <>
+      <p>Hello!</p>
+      <span>{count}</span>
+      <button
+        onClick={() => {
+          console.log("decrement");
+          dispatch(increment(1));
+        }}
+      >
+        Increment
+      </button>
+    </>
+  );
+}

--- a/src/features/observable-counter/Counter.tsx
+++ b/src/features/observable-counter/Counter.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { selectCount, increment, decrement } from "../../app/store";
+import { selectCount, increment, decrement } from "./counterSlice";
 import { useAppDispatch, useAppSelector } from "../../app/hooks";
 
 export function Counter() {

--- a/src/features/observable-counter/counterSlice.ts
+++ b/src/features/observable-counter/counterSlice.ts
@@ -1,0 +1,37 @@
+import { RootState, reducers } from "../../app/store";
+import { PayloadAction, createSlice, AnyAction } from "@reduxjs/toolkit";
+import { createEpicMiddleware, Epic } from "redux-observable";
+import { filter, map, delay } from "rxjs/operators";
+
+export const counter = createSlice({
+  name: "observable/counter",
+  initialState: 0,
+  reducers: {
+    increment: (state, action: PayloadAction<number>) => state + action.payload,
+    decrement: (state, action: PayloadAction<number>) => state - action.payload,
+  },
+});
+
+export const { increment, decrement } = counter.actions;
+
+
+export default counter.reducer;
+
+// what's the difference with RootState?
+// export type MyState = ReturnType<typeof counter.reducer>;
+type MyState = ReturnType<typeof reducers>;
+type MyEpic = Epic<AnyAction, AnyAction, MyState>;
+
+export const selectCount = (state: RootState) => state.observable;
+
+const countEpic: MyEpic = (action$) => {
+  return action$.pipe(
+    filter(counter.actions.increment.match),
+    delay(5000),
+    map((action) => counter.actions.decrement(action.payload))
+  );
+};
+
+export const epicMiddleware = createEpicMiddleware<AnyAction, AnyAction, MyState>();
+
+epicMiddleware.run(countEpic);


### PR DESCRIPTION
This PR adds the same implementation done with `thunk` in `@reduxjs/toolkit` but using `redux-observable` `v2`.